### PR TITLE
[Feat] #2 - 기업별 정보 공유 조회 API 구현

### DIFF
--- a/src/main/java/com/threego/algo/career/command/domain/aggregate/CareerInfoPost.java
+++ b/src/main/java/com/threego/algo/career/command/domain/aggregate/CareerInfoPost.java
@@ -1,0 +1,51 @@
+package com.threego.algo.career.command.domain.aggregate;
+
+import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.member.command.domain.aggregate.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "Career_Info_Post")
+@Entity
+public class CareerInfoPost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.NONE;
+
+    @Column(name = "reject_reason", length = 255)
+    private String rejectReason;
+
+    @Column(nullable = false, length = 1)
+    private String visibility = "Y";
+
+    @Lob
+    private String content;
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
+    @Column(name = "comment_count")
+    private int commentCount = 0;
+
+    @Column(name = "like_count")
+    private int likeCount = 0;
+
+    @Column(name = "created_at", nullable = false, length = 20)
+    private String createdAt;
+}

--- a/src/main/java/com/threego/algo/career/command/domain/aggregate/enums/Status.java
+++ b/src/main/java/com/threego/algo/career/command/domain/aggregate/enums/Status.java
@@ -1,0 +1,5 @@
+package com.threego.algo.career.command.domain.aggregate.enums;
+
+public enum Status {
+    NONE, PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
@@ -45,4 +45,13 @@ public class AdminCareerInfoController {
     ){
         return ResponseEntity.ok(careerInfoService.findPostForAdmin(postId));
     }
+
+    @Operation(
+            summary = "관리자용 기업별 정보 공유 게시물의 댓글 전체 조회",
+            description = "관리자는 모든 댓글을 조회할 수 있습니다."
+    )
+    @GetMapping("/comments")
+    public ResponseEntity<List<PostDetailResponseDto>> findComments(){
+        return ResponseEntity.ok(careerInfoService.findCommentsForAdmin());
+    }
 }

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
@@ -1,9 +1,10 @@
 package com.threego.algo.career.query.controller;
 
+import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import com.threego.algo.career.query.service.CareerInfoService;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,26 +14,26 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "Career Info", description = "회원용 기업별 정보 공유 API")
+@Tag(name = "Career Info (Admin)", description = "관리자용 기업별 정보 공유 API")
 @RestController
-@RequestMapping("/career-info")
-public class CareerInfoController {
-
+@RequestMapping("/admin/career-info")
+public class AdminCareerInfoController {
     private final CareerInfoService careerInfoService;
 
     @Autowired
-    public CareerInfoController(CareerInfoService careerInfoService) {
+    public AdminCareerInfoController(CareerInfoService careerInfoService) {
         this.careerInfoService = careerInfoService;
     }
 
     @Operation(
-            summary = "회원용 기업별 정보 공유 게시물 목록 조회",
-            description = "회원은 공개된 게시물만 최신순으로 조회합니다."
+            summary = "관리자용 기업별 정보 공유 게시물 목록 조회",
+            description = "관리자는 전체 게시물을 조회할 수 있으며, status, keyword 조건을 추가할 수 있습니다."
     )
     @GetMapping("/posts")
     public ResponseEntity<List<PostSummaryResponseDto>> findPosts(
+            @RequestParam(required = false) Status status,
             @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(careerInfoService.findPosts("Y", null, keyword));
+        return ResponseEntity.ok(careerInfoService.findPosts(null, status, keyword));
     }
 }

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
@@ -28,11 +28,11 @@ public class AdminCareerInfoController {
             description = "관리자는 전체 게시물을 조회할 수 있으며, status, keyword 조건을 추가할 수 있습니다."
     )
     @GetMapping("/posts")
-    public ResponseEntity<List<PostSummaryResponseDto>> findPosts(
+    public ResponseEntity<List<PostSummaryResponseDto>> findPostList(
             @RequestParam(required = false) Status status,
             @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(careerInfoService.findPosts(null, status, keyword));
+        return ResponseEntity.ok(careerInfoService.findPostList(null, status, keyword));
     }
 
     @Operation(

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
@@ -1,16 +1,14 @@
 package com.threego.algo.career.query.controller;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import com.threego.algo.career.query.service.CareerInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -35,5 +33,16 @@ public class AdminCareerInfoController {
             @RequestParam(required = false) String keyword
     ) {
         return ResponseEntity.ok(careerInfoService.findPosts(null, status, keyword));
+    }
+
+    @Operation(
+            summary = "관리자용 기업별 정보 공유 게시물 상세 조회",
+            description = "관리자는 모든 게시물을 상세 조회할 수 있습니다."
+    )
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailResponseDto> findPost(
+            @PathVariable int postId
+    ){
+        return ResponseEntity.ok(careerInfoService.findPostForAdmin(postId));
     }
 }

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerInfoController.java
@@ -29,10 +29,11 @@ public class AdminCareerInfoController {
     )
     @GetMapping("/posts")
     public ResponseEntity<List<PostSummaryResponseDto>> findPostList(
+            @RequestParam(required = false) String visibility,
             @RequestParam(required = false) Status status,
             @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(careerInfoService.findPostList(null, status, keyword));
+        return ResponseEntity.ok(careerInfoService.findPostList(visibility, status, keyword));
     }
 
     @Operation(

--- a/src/main/java/com/threego/algo/career/query/controller/AdminCareerQueryController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/AdminCareerQueryController.java
@@ -3,7 +3,7 @@ package com.threego.algo.career.query.controller;
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
-import com.threego.algo.career.query.service.CareerInfoService;
+import com.threego.algo.career.query.service.CareerQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,12 +15,12 @@ import java.util.List;
 @Tag(name = "Career Info (Admin)", description = "관리자용 기업별 정보 공유 API")
 @RestController
 @RequestMapping("/admin/career-info")
-public class AdminCareerInfoController {
-    private final CareerInfoService careerInfoService;
+public class AdminCareerQueryController {
+    private final CareerQueryService careerInfoService;
 
     @Autowired
-    public AdminCareerInfoController(CareerInfoService careerInfoService) {
-        this.careerInfoService = careerInfoService;
+    public AdminCareerQueryController(CareerQueryService careerQueryService) {
+        this.careerInfoService = careerQueryService;
     }
 
     @Operation(

--- a/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
@@ -1,15 +1,13 @@
 package com.threego.algo.career.query.controller;
 
+import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import com.threego.algo.career.query.service.CareerInfoService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,5 +32,16 @@ public class CareerInfoController {
             @RequestParam(required = false) String keyword
     ) {
         return ResponseEntity.ok(careerInfoService.findPosts("Y", null, keyword));
+    }
+
+    @Operation(
+            summary = "회원용 기업별 정보 공유 게시물 상세 조회",
+            description = "회원은 공개된 게시물만 상세 조회할 수 있습니다."
+    )
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailResponseDto> findPost(
+            @PathVariable int postId
+    ){
+        return ResponseEntity.ok(careerInfoService.findPostForMember(postId));
     }
 }

--- a/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
@@ -1,0 +1,35 @@
+package com.threego.algo.career.query.controller;
+
+import com.threego.algo.career.query.dto.PostSummaryResponseDto;
+import com.threego.algo.career.query.service.CareerInfoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Career Info", description = "기업별 정보 공유 API")
+@RestController
+@RequestMapping("/career-info")
+public class CareerInfoController {
+
+    private final CareerInfoService careerInfoService;
+
+    @Autowired
+    public CareerInfoController(CareerInfoService careerInfoService) {
+        this.careerInfoService = careerInfoService;
+    }
+
+    @Operation(
+            summary = "기업별 정보 공유 게시물 목록 조회",
+            description = "기업별 정보 공유 게시물을 최신순으로 조회합니다. (목록)"
+    )
+    @GetMapping("/posts")
+    public ResponseEntity<List<PostSummaryResponseDto>> findPosts() {
+        return ResponseEntity.ok(careerInfoService.findPosts());
+    }
+}

--- a/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
@@ -28,10 +28,10 @@ public class CareerInfoController {
             description = "회원은 공개된 게시물만 최신순으로 조회합니다."
     )
     @GetMapping("/posts")
-    public ResponseEntity<List<PostSummaryResponseDto>> findPosts(
+    public ResponseEntity<List<PostSummaryResponseDto>> findPostList(
             @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(careerInfoService.findPosts("Y", null, keyword));
+        return ResponseEntity.ok(careerInfoService.findPostList("Y", null, keyword));
     }
 
     @Operation(

--- a/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/CareerInfoController.java
@@ -1,5 +1,6 @@
 package com.threego.algo.career.query.controller;
 
+import com.threego.algo.career.query.dto.CommentResponseDto;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import com.threego.algo.career.query.service.CareerInfoService;
@@ -43,5 +44,17 @@ public class CareerInfoController {
             @PathVariable int postId
     ){
         return ResponseEntity.ok(careerInfoService.findPostForMember(postId));
+    }
+
+    @Operation(
+            summary = "기업별 정보 공유 게시물의 댓글 조회",
+            description = "특정 게시물에 달린 모든 댓글을 조회합니다. " +
+                    "visibility 여부와 관계없이 모두 내려주며, 프론트에서 처리(블러)합니다."
+    )
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<List<CommentResponseDto>> findComments(
+            @PathVariable int postId
+    ){
+        return ResponseEntity.ok(careerInfoService.findCommentsByPostId(postId));
     }
 }

--- a/src/main/java/com/threego/algo/career/query/controller/CareerQueryController.java
+++ b/src/main/java/com/threego/algo/career/query/controller/CareerQueryController.java
@@ -3,7 +3,7 @@ package com.threego.algo.career.query.controller;
 import com.threego.algo.career.query.dto.CommentResponseDto;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
-import com.threego.algo.career.query.service.CareerInfoService;
+import com.threego.algo.career.query.service.CareerQueryService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,13 +15,13 @@ import java.util.List;
 @Tag(name = "Career Info", description = "회원용 기업별 정보 공유 API")
 @RestController
 @RequestMapping("/career-info")
-public class CareerInfoController {
+public class CareerQueryController {
 
-    private final CareerInfoService careerInfoService;
+    private final CareerQueryService careerQueryService;
 
     @Autowired
-    public CareerInfoController(CareerInfoService careerInfoService) {
-        this.careerInfoService = careerInfoService;
+    public CareerQueryController(CareerQueryService careerQueryService) {
+        this.careerQueryService = careerQueryService;
     }
 
     @Operation(
@@ -32,7 +32,7 @@ public class CareerInfoController {
     public ResponseEntity<List<PostSummaryResponseDto>> findPostList(
             @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(careerInfoService.findPostList("Y", null, keyword));
+        return ResponseEntity.ok(careerQueryService.findPostList("Y", null, keyword));
     }
 
     @Operation(
@@ -43,7 +43,7 @@ public class CareerInfoController {
     public ResponseEntity<PostDetailResponseDto> findPost(
             @PathVariable int postId
     ){
-        return ResponseEntity.ok(careerInfoService.findPostForMember(postId));
+        return ResponseEntity.ok(careerQueryService.findPostForMember(postId));
     }
 
     @Operation(
@@ -55,6 +55,6 @@ public class CareerInfoController {
     public ResponseEntity<List<CommentResponseDto>> findComments(
             @PathVariable int postId
     ){
-        return ResponseEntity.ok(careerInfoService.findCommentsByPostId(postId));
+        return ResponseEntity.ok(careerQueryService.findCommentsByPostId(postId));
     }
 }

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -1,6 +1,7 @@
 package com.threego.algo.career.query.dao;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -12,5 +13,11 @@ public interface CareerInfoMapper {
     List<PostSummaryResponseDto> findPosts(
             @Param("visibility") String visibility,
             @Param("status") Status status,
-            @Param("keyword") String keyword);
+            @Param("keyword") String keyword
+    );
+
+    PostDetailResponseDto selectPost(
+            @Param("postId") int postId,
+            @Param("visibility") String visibility
+    );
 }

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -1,0 +1,11 @@
+package com.threego.algo.career.query.dao;
+
+import com.threego.algo.career.query.dto.PostSummaryResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface CareerInfoMapper {
+    List<PostSummaryResponseDto> findPosts();
+}

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -25,4 +25,6 @@ public interface CareerInfoMapper {
     List<CommentResponseDto> selectCommentsByPostId(
             @Param("postId") int postId
     );
+
+    List<PostDetailResponseDto> selectComments();
 }

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -1,11 +1,16 @@
 package com.threego.algo.career.query.dao;
 
+import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface CareerInfoMapper {
-    List<PostSummaryResponseDto> findPosts();
+    List<PostSummaryResponseDto> findPosts(
+            @Param("visibility") String visibility,
+            @Param("status") Status status,
+            @Param("keyword") String keyword);
 }

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Mapper
 public interface CareerInfoMapper {
-    List<PostSummaryResponseDto> findPosts(
+    List<PostSummaryResponseDto> selectPostList(
             @Param("visibility") String visibility,
             @Param("status") Status status,
             @Param("keyword") String keyword

--- a/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
+++ b/src/main/java/com/threego/algo/career/query/dao/CareerInfoMapper.java
@@ -1,6 +1,7 @@
 package com.threego.algo.career.query.dao;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.career.query.dto.CommentResponseDto;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.apache.ibatis.annotations.Mapper;
@@ -19,5 +20,9 @@ public interface CareerInfoMapper {
     PostDetailResponseDto selectPost(
             @Param("postId") int postId,
             @Param("visibility") String visibility
+    );
+
+    List<CommentResponseDto> selectCommentsByPostId(
+            @Param("postId") int postId
     );
 }

--- a/src/main/java/com/threego/algo/career/query/dto/CommentResponseDto.java
+++ b/src/main/java/com/threego/algo/career/query/dto/CommentResponseDto.java
@@ -1,0 +1,27 @@
+package com.threego.algo.career.query.dto;
+
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponseDto {
+    private int commentId;
+    private Integer parentId; // nullable
+    private int postId;
+    private int memberId;
+    private String nickname;
+    private String rankName;
+    private String content;
+    private String createdAt;
+    private String updatedAt;
+    private String visibility;
+
+    // 대댓글용 children
+    @Setter
+    private List<CommentResponseDto> children = new ArrayList<>();
+}

--- a/src/main/java/com/threego/algo/career/query/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/threego/algo/career/query/dto/PostDetailResponseDto.java
@@ -1,0 +1,27 @@
+package com.threego.algo.career.query.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostDetailResponseDto {
+    private int id;
+    private String title;
+    private String content;
+
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String imageUrl; // null이면 json에서 제외
+
+    private int memberId;
+    private String nickname;
+    private String rankName;
+    private String createdAt;
+    private String status;
+    private String rejectReason;
+    private int likeCount;
+    private int commentCount;
+}

--- a/src/main/java/com/threego/algo/career/query/dto/PostSummaryResponseDto.java
+++ b/src/main/java/com/threego/algo/career/query/dto/PostSummaryResponseDto.java
@@ -1,0 +1,19 @@
+package com.threego.algo.career.query.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostSummaryResponseDto {
+    private int id;
+    private String title;
+    private int memberId;
+    private String nickname;
+    private String rankName;
+    private String createdAt;
+    private String status;
+    private int likeCount;
+    private int commentCount;
+}

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -1,5 +1,6 @@
 package com.threego.algo.career.query.service;
 
+import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.springframework.stereotype.Service;
 
@@ -7,5 +8,5 @@ import java.util.List;
 
 public interface CareerInfoService{
 
-    List<PostSummaryResponseDto> findPosts();
+    List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword);
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -1,6 +1,7 @@
 package com.threego.algo.career.query.service;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +10,7 @@ import java.util.List;
 public interface CareerInfoService{
 
     List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword);
+    PostDetailResponseDto findPostForMember(int postId);
+    PostDetailResponseDto findPostForAdmin(int postId);
+
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -1,0 +1,11 @@
+package com.threego.algo.career.query.service;
+
+import com.threego.algo.career.query.dto.PostSummaryResponseDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+public interface CareerInfoService{
+
+    List<PostSummaryResponseDto> findPosts();
+}

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -13,4 +13,5 @@ public interface CareerInfoService{
     PostDetailResponseDto findPostForMember(int postId);
     PostDetailResponseDto findPostForAdmin(int postId);
     List<CommentResponseDto> findCommentsByPostId(int postId);
+    List<PostDetailResponseDto> findCommentsForAdmin();
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -3,13 +3,12 @@ package com.threego.algo.career.query.service;
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 public interface CareerInfoService{
 
-    List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword);
+    List<PostSummaryResponseDto> findPostList(String visibility, Status status, String keyword);
     PostDetailResponseDto findPostForMember(int postId);
     PostDetailResponseDto findPostForAdmin(int postId);
 

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoService.java
@@ -1,6 +1,7 @@
 package com.threego.algo.career.query.service;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
+import com.threego.algo.career.query.dto.CommentResponseDto;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 
@@ -11,5 +12,5 @@ public interface CareerInfoService{
     List<PostSummaryResponseDto> findPostList(String visibility, Status status, String keyword);
     PostDetailResponseDto findPostForMember(int postId);
     PostDetailResponseDto findPostForAdmin(int postId);
-
+    List<CommentResponseDto> findCommentsByPostId(int postId);
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -1,5 +1,6 @@
 package com.threego.algo.career.query.service;
 
+import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dao.CareerInfoMapper;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ public class CareerInfoServiceImpl implements CareerInfoService{
     }
 
     @Override
-    public List<PostSummaryResponseDto> findPosts() {
-        return careerInfoMapper.findPosts();
+    public List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword) {
+        return careerInfoMapper.findPosts(visibility, status, keyword);
     }
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -2,6 +2,7 @@ package com.threego.algo.career.query.service;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dao.CareerInfoMapper;
+import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,4 +22,17 @@ public class CareerInfoServiceImpl implements CareerInfoService{
     public List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword) {
         return careerInfoMapper.findPosts(visibility, status, keyword);
     }
+
+    @Override
+    public PostDetailResponseDto findPostForMember(int postId) {
+        PostDetailResponseDto dto = careerInfoMapper.selectPost(postId, "Y");
+        dto.setImageUrl(null);  // 회원에게는 이미지 숨김
+        return dto;
+    }
+
+    @Override
+    public PostDetailResponseDto findPostForAdmin(int postId) {
+        return careerInfoMapper.selectPost(postId, null);
+    }
+
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -1,0 +1,23 @@
+package com.threego.algo.career.query.service;
+
+import com.threego.algo.career.query.dao.CareerInfoMapper;
+import com.threego.algo.career.query.dto.PostSummaryResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CareerInfoServiceImpl implements CareerInfoService{
+    private final CareerInfoMapper careerInfoMapper;
+
+    @Autowired
+    public CareerInfoServiceImpl(CareerInfoMapper careerInfoMapper) {
+        this.careerInfoMapper = careerInfoMapper;
+    }
+
+    @Override
+    public List<PostSummaryResponseDto> findPosts() {
+        return careerInfoMapper.findPosts();
+    }
+}

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -19,8 +19,8 @@ public class CareerInfoServiceImpl implements CareerInfoService{
     }
 
     @Override
-    public List<PostSummaryResponseDto> findPosts(String visibility, Status status, String keyword) {
-        return careerInfoMapper.findPosts(visibility, status, keyword);
+    public List<PostSummaryResponseDto> findPostList(String visibility, Status status, String keyword) {
+        return careerInfoMapper.selectPostList(visibility, status, keyword);
     }
 
     @Override

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -2,12 +2,16 @@ package com.threego.algo.career.query.service;
 
 import com.threego.algo.career.command.domain.aggregate.enums.Status;
 import com.threego.algo.career.query.dao.CareerInfoMapper;
+import com.threego.algo.career.query.dto.CommentResponseDto;
 import com.threego.algo.career.query.dto.PostDetailResponseDto;
 import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class CareerInfoServiceImpl implements CareerInfoService{
@@ -34,5 +38,34 @@ public class CareerInfoServiceImpl implements CareerInfoService{
     public PostDetailResponseDto findPostForAdmin(int postId) {
         return careerInfoMapper.selectPost(postId, null);
     }
+
+    @Override
+    public List<CommentResponseDto> findCommentsByPostId(int postId) {
+        List<CommentResponseDto> flatComments
+                = careerInfoMapper.selectCommentsByPostId(postId);
+
+        // 트리 구조로 변환
+        Map<Integer, CommentResponseDto> map = new HashMap<>();
+        List<CommentResponseDto> roots = new ArrayList<>();
+
+        for(CommentResponseDto c : flatComments) {
+            c.setChildren(new ArrayList<>());
+            map.put(c.getCommentId(), c);
+        }
+
+        for(CommentResponseDto c : flatComments) {
+            if(c.getParentId() == null) {
+                roots.add(c);
+            } else {
+                CommentResponseDto parent = map.get(c.getParentId());
+                if (parent != null) {
+                    parent.getChildren().add(c);
+                }
+            }
+        }
+
+        return roots;
+    }
+
 
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerInfoServiceImpl.java
@@ -67,5 +67,9 @@ public class CareerInfoServiceImpl implements CareerInfoService{
         return roots;
     }
 
+    @Override
+    public List<PostDetailResponseDto> findCommentsForAdmin() {
+        return careerInfoMapper.selectComments();
+    }
 
 }

--- a/src/main/java/com/threego/algo/career/query/service/CareerQueryService.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerQueryService.java
@@ -7,7 +7,7 @@ import com.threego.algo.career.query.dto.PostSummaryResponseDto;
 
 import java.util.List;
 
-public interface CareerInfoService{
+public interface CareerQueryService {
 
     List<PostSummaryResponseDto> findPostList(String visibility, Status status, String keyword);
     PostDetailResponseDto findPostForMember(int postId);

--- a/src/main/java/com/threego/algo/career/query/service/CareerQueryServiceImpl.java
+++ b/src/main/java/com/threego/algo/career/query/service/CareerQueryServiceImpl.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.Map;
 
 @Service
-public class CareerInfoServiceImpl implements CareerInfoService{
+public class CareerQueryServiceImpl implements CareerQueryService {
     private final CareerInfoMapper careerInfoMapper;
 
     @Autowired
-    public CareerInfoServiceImpl(CareerInfoMapper careerInfoMapper) {
+    public CareerQueryServiceImpl(CareerInfoMapper careerInfoMapper) {
         this.careerInfoMapper = careerInfoMapper;
     }
 

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="com.threego.algo.career.query.dao.CareerInfoMapper">
     
-    <select id="findPosts" resultType="com.threego.algo.career.query.dto.PostSummaryResponseDto">
+    <select id="selectPostList" resultType="com.threego.algo.career.query.dto.PostSummaryResponseDto">
         SELECT
                A.ID AS id
              , A.TITLE AS title

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -32,5 +32,31 @@
         </where>
          ORDER BY A.ID DESC
     </select>
+    
+    <select id="selectPost" resultType="com.threego.algo.career.query.dto.PostDetailResponseDto">
+        SELECT
+               A.ID            AS id
+             , A.TITLE         AS title
+             , A.CONTENT       AS content
+             , A.IMAGE_URL     AS imageUrl
+             , A.MEMBER_ID     AS memberId
+             , B.NICKNAME      AS nickname
+             , C.NAME          AS rankName
+             , A.CREATED_AT    AS createdAt
+             , A.VISIBILITY    AS visibility
+             , A.STATUS        AS status
+             , A.REJECT_REASON AS rejectReason
+             , A.LIKE_COUNT    AS likeCount
+             , A.COMMENT_COUNT AS commentCount
+          FROM CAREER_INFO_POST A
+          JOIN MEMBER B
+            ON A.MEMBER_ID = B.ID
+          JOIN MEMBER_RANK C
+            ON B.RANK_ID = C.ID
+         WHERE A.ID = #{postId}
+        <if test="visibility != null">
+            AND A.VISIBILITY = #{visibility}
+        </if>
+    </select>
 
 </mapper>

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -19,7 +19,17 @@
           FROM CAREER_INFO_POST A
           JOIN MEMBER B ON A.MEMBER_ID = B.ID
           JOIN MEMBER_RANK C ON B.RANK_ID = C.ID
-         WHERE A.VISIBILITY = 'Y'
+        <where>
+            <if test="visibility != null">
+                A.VISIBILITY = #{visibility}
+            </if>
+            <if test="status != null">
+                AND A.STATUS = #{status}
+            </if>
+            <if test="keyword != null and keyword != ''">
+                AND A.TITLE LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+        </where>
          ORDER BY A.ID DESC
     </select>
 

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -81,4 +81,24 @@
                        ELSE A.PARENT_ID END ASC,
                   A.ID ASC
     </select>
+
+    <select id="selectComments" resultType="com.threego.algo.career.query.dto.CommentResponseDto">
+        SELECT
+               A.ID          AS commentId
+               , A.PARENT_ID   AS parentId
+               , A.POST_ID     AS postId
+               , A.MEMBER_ID   AS memberId
+               , B.NICKNAME    AS nickname
+               , C.NAME        AS rankName
+               , A.CONTENT     AS content
+               , A.CREATED_AT  AS createdAt
+               , A.UPDATED_AT  AS updatedAt
+               , A.VISIBILITY  AS visibility
+            FROM CAREER_INFO_COMMENT A
+            JOIN MEMBER B
+              ON A.MEMBER_ID = B.ID
+            JOIN MEMBER_RANK C
+              ON B.RANK_ID = C.ID
+           ORDER BY A.ID DESC;
+    </select>
 </mapper>

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -59,4 +59,26 @@
         </if>
     </select>
 
+    <select id="selectCommentsByPostId"
+            parameterType="map"
+            resultType="com.threego.algo.career.query.dto.CommentResponseDto">
+        SELECT
+               A.ID          AS commentId
+             , A.PARENT_ID   AS parentId
+             , A.POST_ID     AS postId
+             , A.MEMBER_ID   AS memberId
+             , B.NICKNAME    AS nickname
+             , C.NAME        AS rankName
+             , A.CONTENT     AS content
+             , A.CREATED_AT  AS createdAt
+             , A.UPDATED_AT  AS updatedAt
+             , A.VISIBILITY  AS visibility
+          FROM CAREER_INFO_COMMENT A
+          JOIN MEMBER B ON A.MEMBER_ID = B.ID
+          JOIN MEMBER_RANK C ON B.RANK_ID = C.ID
+         WHERE A.POST_ID = #{postId}
+         ORDER BY CASE WHEN A.PARENT_ID IS NULL THEN A.ID
+                       ELSE A.PARENT_ID END ASC,
+                  A.ID ASC
+    </select>
 </mapper>

--- a/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
+++ b/src/main/resources/com/threego/algo/career/query/dao/CareerInfoMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.threego.algo.career.query.dao.CareerInfoMapper">
+    
+    <select id="findPosts" resultType="com.threego.algo.career.query.dto.PostSummaryResponseDto">
+        SELECT
+               A.ID AS id
+             , A.TITLE AS title
+             , A.MEMBER_ID AS memberId
+             , B.NICKNAME AS nickname
+             , C.NAME AS rankName
+             , A.CREATED_AT AS createdAt
+             , A.STATUS AS status
+             , A.LIKE_COUNT AS likeCount
+             , A.COMMENT_COUNT AS commentCount
+          FROM CAREER_INFO_POST A
+          JOIN MEMBER B ON A.MEMBER_ID = B.ID
+          JOIN MEMBER_RANK C ON B.RANK_ID = C.ID
+         WHERE A.VISIBILITY = 'Y'
+         ORDER BY A.ID DESC
+    </select>
+
+</mapper>


### PR DESCRIPTION
## Pull Request
### ISSUE
- #2

### Develop
기업별 정보 공유 조회 API 구현

**회원**
- 회원용 게시물 목록 조회 API (GET /career-info/posts)
- 회원용 게시물 상세 조회 API (GET /career-info/posts/{postId})
- 게시물에 달린 댓글 조회 API (GET /career-info/posts/{postId}/comments)

**관리자**
- 관리자용 게시물 목록 조회 API (GET /admin/career-info/posts)
- 관리자용 게시물 상세 조회 API (GET /admin/career-info/posts/{postId})
- 관리자용 전체 댓글 조회 API (GET /admin/career-info/comments)

### Test
<img width="1177" height="376" alt="image" src="https://github.com/user-attachments/assets/584a20ba-a636-42f3-ab66-3e07d541fc8e" />